### PR TITLE
fix(eslint): useFlatConfig is not experimental anymore

### DIFF
--- a/lua/lspconfig/server_configurations/eslint.lua
+++ b/lua/lspconfig/server_configurations/eslint.lua
@@ -84,9 +84,7 @@ return {
       validate = 'on',
       packageManager = 'npm',
       useESLintClass = false,
-      experimental = {
-        useFlatConfig = false,
-      },
+      useFlatConfig = false,
       codeActionOnSave = {
         enable = false,
         mode = 'all',


### PR DESCRIPTION
Because of this [PR](https://github.com/neovim/nvim-lspconfig/pull/3183), getting [error](https://github.com/neovim/nvim-lspconfig/pull/3183#issuecomment-2139799111)

also ```useFlatConfig``` is not experimental anymore.